### PR TITLE
인가 기능 구현 및 인증/인가 테스트

### DIFF
--- a/src/main/java/com/theZ/dotoring/app/auth/FilterResponseUtils.java
+++ b/src/main/java/com/theZ/dotoring/app/auth/FilterResponseUtils.java
@@ -33,4 +33,10 @@ public class FilterResponseUtils {
     }
 
 
+    public static void reRequest(HttpServletResponse response) throws IOException {
+        ApiResponse<?> apiResponse = ApiResponseGenerator.fail(MessageCode.EXPIRED_ACCESS_TOKEN.getCode(), MessageCode.EXPIRED_ACCESS_TOKEN.getValue(), HttpStatus.UNAUTHORIZED);
+        response.setCharacterEncoding("UTF-8");
+        response.setContentType("application/json");
+        response.getWriter().write(new ObjectMapper().writeValueAsString(apiResponse.getBody()));
+    }
 }

--- a/src/main/java/com/theZ/dotoring/app/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/theZ/dotoring/app/auth/JwtAuthenticationFilter.java
@@ -59,7 +59,7 @@ public class JwtAuthenticationFilter extends BasicAuthenticationFilter {
                 log.debug("isValidRefreshToken, {}", true);
                 chain.doFilter(request,response);
             }else if(refreshTokenStatus == TokenStatus.INVALID){
-                log.debug("isValidRefreshToken, {}", false);
+                log.debug("isInValidRefreshToken, {}", false);
                 FilterResponsor.invalidRefreshToken(response);
             }else {
                 log.debug("isExpiredRefreshToken, {}", true);
@@ -67,8 +67,6 @@ public class JwtAuthenticationFilter extends BasicAuthenticationFilter {
             }
 
         }
-
-
     }
 
     private String getRefreshToken(Optional<Cookie[]> cookies){

--- a/src/main/java/com/theZ/dotoring/app/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/theZ/dotoring/app/auth/JwtAuthenticationFilter.java
@@ -43,6 +43,7 @@ public class JwtAuthenticationFilter extends BasicAuthenticationFilter {
             Authentication authentication = memberDetailService.getAuthentication(accessToken.get());
             SecurityContextHolder.getContext().setAuthentication(authentication);
             chain.doFilter(request,response);
+            return;
         }
 
         boolean expiredToken = Token.isExpiredToken(accessToken.get());

--- a/src/main/java/com/theZ/dotoring/app/auth/TokenStatus.java
+++ b/src/main/java/com/theZ/dotoring/app/auth/TokenStatus.java
@@ -1,0 +1,5 @@
+package com.theZ.dotoring.app.auth;
+
+public enum TokenStatus {
+    VALID, INVALID, EXPIRED
+}

--- a/src/main/java/com/theZ/dotoring/app/auth/controller/AuthController.java
+++ b/src/main/java/com/theZ/dotoring/app/auth/controller/AuthController.java
@@ -6,13 +6,11 @@ import com.theZ.dotoring.app.auth.model.Token;
 import com.theZ.dotoring.app.auth.service.MemberDetailService;
 import com.theZ.dotoring.common.ApiResponse;
 import com.theZ.dotoring.common.ApiResponseGenerator;
-import com.theZ.dotoring.common.MessageCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -36,7 +34,6 @@ public class AuthController {
         String refreshToken = Arrays.stream(request.getCookies()).filter(cookie -> cookie.getName().equals("refreshToken")).findAny().orElseThrow(() -> new IllegalStateException("refreshToken 이라는 이름을 가진 cookie가 없습니다.")).getValue();
         String loginIdFromAccessToken = token.getSubjectFormToken(accessToken);
         String loginIdFromRefreshToken = token.getSubjectFormToken(refreshToken);
-
         verifySameLoginId(response, loginIdFromAccessToken, loginIdFromRefreshToken);
 
         return ApiResponseGenerator.success(HttpStatus.OK);

--- a/src/main/java/com/theZ/dotoring/app/auth/controller/AuthController.java
+++ b/src/main/java/com/theZ/dotoring/app/auth/controller/AuthController.java
@@ -30,11 +30,6 @@ public class AuthController {
     private final Token token;
     private final MemberDetailService memberDetailService;
 
-    @GetMapping("/auth/reRequest")
-    public ApiResponse<ApiResponse.CustomBody> alertExpiredToken() {
-        return ApiResponseGenerator.fail(MessageCode.EXPIRED_ACCESS_TOKEN.getCode(),MessageCode.EXPIRED_ACCESS_TOKEN.getValue(), HttpStatus.OK);
-    }
-
     @PostMapping("/auth/reIssue")
     public ApiResponse<ApiResponse.CustomBody<Void>> reissueTokens(HttpServletRequest request, HttpServletResponse response) {
         String accessToken = request.getHeader(AuthConstants.AUTH_HEADER);

--- a/src/main/java/com/theZ/dotoring/app/auth/controller/FilterResponsor.java
+++ b/src/main/java/com/theZ/dotoring/app/auth/controller/FilterResponsor.java
@@ -1,4 +1,4 @@
-package com.theZ.dotoring.app.auth;
+package com.theZ.dotoring.app.auth.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.theZ.dotoring.common.ApiResponse;
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
-public class FilterResponseUtils {
+public class FilterResponsor {
 
     public static void unAuthorized(HttpServletResponse response) throws IOException {
         ApiResponse<?> apiResponse = ApiResponseGenerator.fail(MessageCode.REQUIRE_LOGIN.getCode(), MessageCode.REQUIRE_LOGIN.getValue(), HttpStatus.UNAUTHORIZED);
@@ -35,6 +35,13 @@ public class FilterResponseUtils {
 
     public static void reRequest(HttpServletResponse response) throws IOException {
         ApiResponse<?> apiResponse = ApiResponseGenerator.fail(MessageCode.EXPIRED_ACCESS_TOKEN.getCode(), MessageCode.EXPIRED_ACCESS_TOKEN.getValue(), HttpStatus.UNAUTHORIZED);
+        response.setCharacterEncoding("UTF-8");
+        response.setContentType("application/json");
+        response.getWriter().write(new ObjectMapper().writeValueAsString(apiResponse.getBody()));
+    }
+
+    public static void reLogin(HttpServletResponse response) throws IOException {
+        ApiResponse<?> apiResponse = ApiResponseGenerator.fail(MessageCode.EXPIRED_REFRESH_TOKEN.getCode(), MessageCode.EXPIRED_REFRESH_TOKEN.getValue(), HttpStatus.UNAUTHORIZED);
         response.setCharacterEncoding("UTF-8");
         response.setContentType("application/json");
         response.getWriter().write(new ObjectMapper().writeValueAsString(apiResponse.getBody()));

--- a/src/main/java/com/theZ/dotoring/app/auth/controller/FilterResponsor.java
+++ b/src/main/java/com/theZ/dotoring/app/auth/controller/FilterResponsor.java
@@ -12,7 +12,7 @@ import java.io.IOException;
 public class FilterResponsor {
 
     public static void unAuthorized(HttpServletResponse response) throws IOException {
-        ApiResponse<?> apiResponse = ApiResponseGenerator.fail(MessageCode.REQUIRE_LOGIN.getCode(), MessageCode.REQUIRE_LOGIN.getValue(), HttpStatus.UNAUTHORIZED);
+        ApiResponse<?> apiResponse = ApiResponseGenerator.fail(MessageCode.REQUIRE_ACCESS.getCode(), MessageCode.REQUIRE_ACCESS.getValue(), HttpStatus.UNAUTHORIZED);
         response.setCharacterEncoding("UTF-8");
         response.setContentType("application/json");
         response.getWriter().write(new ObjectMapper().writeValueAsString(apiResponse.getBody()));

--- a/src/main/java/com/theZ/dotoring/app/auth/model/Token.java
+++ b/src/main/java/com/theZ/dotoring/app/auth/model/Token.java
@@ -95,10 +95,8 @@ public class Token {
             getClaimsFormToken(accessToken);
             return TokenStatus.VALID;
         } catch (MalformedJwtException e) {
-            FilterResponsor.invalidAccessToken(response);
             return TokenStatus.INVALID;
         } catch (IllegalArgumentException e) {
-            FilterResponsor.invalidAccessToken(response);
             return TokenStatus.INVALID;
         } catch(ExpiredJwtException e){
             return TokenStatus.EXPIRED;

--- a/src/main/java/com/theZ/dotoring/common/MessageCode.java
+++ b/src/main/java/com/theZ/dotoring/common/MessageCode.java
@@ -3,7 +3,7 @@ package com.theZ.dotoring.common;
 public enum MessageCode {
 
     REQUIRE_LOGIN("1010","로그인이 필요합니다."),
-    EXPIRED_ACCESS_TOKEN("8080","만료된 AccessToken입니다. 재발행 요청을 해주세요."),
+    EXPIRED_ACCESS_TOKEN("9001","만료된 AccessToken입니다. 재발행 요청을 해주세요."),
 
     INVALID_ACCESS_TOKEN("9000","잘못된 AccessToken입니다."),
     INVALID_REFRESH_TOKEN("1919","잘못된 RefreshToken입니다."),

--- a/src/main/java/com/theZ/dotoring/common/MessageCode.java
+++ b/src/main/java/com/theZ/dotoring/common/MessageCode.java
@@ -7,7 +7,7 @@ public enum MessageCode {
     EXPIRED_REFRESH_TOKEN("9002","만료된 RefreshToken입니다. 다시 로그인을 해주세요."),
 
     INVALID_ACCESS_TOKEN("9000","잘못된 AccessToken입니다."),
-    INVALID_REFRESH_TOKEN("1919","잘못된 RefreshToken입니다."),
+    INVALID_REFRESH_TOKEN("9004","잘못된 RefreshToken입니다."),
     NOT_ALLOWED_FILE_EXT("4003","파일 확장명은 pdf,img만 가능합니다."),
     FILE_NOT_INPUT_OUTPUT("4004","파일 입출력 오류입니다."),
     FILE_SAVE_FAIL("4005","파일 저장에 실패하였습니다."),

--- a/src/main/java/com/theZ/dotoring/common/MessageCode.java
+++ b/src/main/java/com/theZ/dotoring/common/MessageCode.java
@@ -4,6 +4,7 @@ public enum MessageCode {
 
     REQUIRE_LOGIN("1010","로그인이 필요합니다."),
     EXPIRED_ACCESS_TOKEN("9001","만료된 AccessToken입니다. 재발행 요청을 해주세요."),
+    EXPIRED_REFRESH_TOKEN("9002","만료된 RefreshToken입니다. 다시 로그인을 해주세요."),
 
     INVALID_ACCESS_TOKEN("9000","잘못된 AccessToken입니다."),
     INVALID_REFRESH_TOKEN("1919","잘못된 RefreshToken입니다."),

--- a/src/main/java/com/theZ/dotoring/common/MessageCode.java
+++ b/src/main/java/com/theZ/dotoring/common/MessageCode.java
@@ -2,7 +2,7 @@ package com.theZ.dotoring.common;
 
 public enum MessageCode {
 
-    REQUIRE_LOGIN("1010","로그인이 필요합니다."),
+    REQUIRE_ACCESS("9003","권한이 없습니다."),
     EXPIRED_ACCESS_TOKEN("9001","만료된 AccessToken입니다. 재발행 요청을 해주세요."),
     EXPIRED_REFRESH_TOKEN("9002","만료된 RefreshToken입니다. 다시 로그인을 해주세요."),
 

--- a/src/main/java/com/theZ/dotoring/common/MessageCode.java
+++ b/src/main/java/com/theZ/dotoring/common/MessageCode.java
@@ -7,7 +7,7 @@ public enum MessageCode {
     EXPIRED_REFRESH_TOKEN("9002","만료된 RefreshToken입니다. 다시 로그인을 해주세요."),
 
     INVALID_ACCESS_TOKEN("9000","잘못된 AccessToken입니다."),
-    INVALID_REFRESH_TOKEN("9004","잘못된 RefreshToken입니다."),
+    INVALID_REFRESH_TOKEN("9004","잘못된 RefreshToken입니다. 다시 로그인을 해주세요."),
     NOT_ALLOWED_FILE_EXT("4003","파일 확장명은 pdf,img만 가능합니다."),
     FILE_NOT_INPUT_OUTPUT("4004","파일 입출력 오류입니다."),
     FILE_SAVE_FAIL("4005","파일 저장에 실패하였습니다."),

--- a/src/main/java/com/theZ/dotoring/common/MessageCode.java
+++ b/src/main/java/com/theZ/dotoring/common/MessageCode.java
@@ -5,7 +5,7 @@ public enum MessageCode {
     REQUIRE_LOGIN("1010","로그인이 필요합니다."),
     EXPIRED_ACCESS_TOKEN("8080","만료된 AccessToken입니다. 재발행 요청을 해주세요."),
 
-    INVALID_ACCESS_TOKEN("9919","잘못된 AccessToken입니다."),
+    INVALID_ACCESS_TOKEN("9000","잘못된 AccessToken입니다."),
     INVALID_REFRESH_TOKEN("1919","잘못된 RefreshToken입니다."),
     NOT_ALLOWED_FILE_EXT("4003","파일 확장명은 pdf,img만 가능합니다."),
     FILE_NOT_INPUT_OUTPUT("4004","파일 입출력 오류입니다."),

--- a/src/main/java/com/theZ/dotoring/config/WebSecurityConfig.java
+++ b/src/main/java/com/theZ/dotoring/config/WebSecurityConfig.java
@@ -2,7 +2,7 @@ package com.theZ.dotoring.config;
 
 import com.theZ.dotoring.app.auth.DotoringAuthenticationFilter;
 import com.theZ.dotoring.app.auth.DotoringAuthenticationProvider;
-import com.theZ.dotoring.app.auth.FilterResponseUtils;
+import com.theZ.dotoring.app.auth.controller.FilterResponsor;
 import com.theZ.dotoring.app.auth.JwtAuthenticationFilter;
 import com.theZ.dotoring.app.auth.handler.DotoringLoginSuccessHandler;
 import com.theZ.dotoring.app.auth.service.MemberDetailService;
@@ -35,7 +35,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     protected void configure(HttpSecurity http) throws Exception {
 
         http.exceptionHandling().accessDeniedHandler((request, response, authException) -> {
-            FilterResponseUtils.unAuthorized(response);
+            FilterResponsor.unAuthorized(response);
         });
 
         http.headers().frameOptions().disable();
@@ -51,7 +51,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .authorizeRequests()//요청에 대한 인증/인가 규칙을 설정합니다. 즉, 특정한 URL 패턴에 대해 어떤 역할(Role)을 가진 사용자만 접근을 허용할지를 지정합니다.
                     .antMatchers("/api/fields","/api/majors","/api/member/code","/api/member/loginId","/api/member/password",
                             "/api/member/signup/code","/api/member/signup/valid-code","/api/member/valid-code","/api/member/valid-loginId",
-                            "/api/menti/valid-nickname","/api/mento/valid-nickname","/api/member/login","/api/signup-menti","/api/signup-mento").permitAll()
+                            "/api/menti/valid-nickname","/api/mento/valid-nickname","/api/member/login","/api/signup-menti","/api/signup-mento","/api/auth/reIssue").permitAll()
                     .antMatchers("/api/menti/{id}","/api/mento/desiredField","/api/mento/introduction","/api/mento/mentoringSystem","/api/mento/nickname","/api/profile","/api/menti").hasRole("MENTO")
                     .antMatchers("/api/mento/{id}","/api/menti/desiredField","/api/menti/introduction","/api/menti/mentoringSystem","/api/menti/nickname","/api/profile","/api/mento").hasRole("MENTI");
 

--- a/src/main/java/com/theZ/dotoring/config/WebSecurityConfig.java
+++ b/src/main/java/com/theZ/dotoring/config/WebSecurityConfig.java
@@ -20,7 +20,6 @@ import org.springframework.security.web.authentication.www.BasicAuthenticationFi
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-
 import java.util.Arrays;
 
 @Configuration
@@ -85,7 +84,6 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
         jwtAuthenticationFilter.afterPropertiesSet();
         return jwtAuthenticationFilter;
     }
-
     @Override
     public void configure(AuthenticationManagerBuilder authenticationManagerBuilder) {
         authenticationManagerBuilder.authenticationProvider(dotoringAuthenticationProvider());

--- a/src/test/java/com/theZ/dotoring/app/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/theZ/dotoring/app/auth/controller/AuthControllerTest.java
@@ -52,6 +52,32 @@ class AuthControllerTest {
 
     }
 
+    @Test
+    @DisplayName("잘못된 AccessToken을 줄 때")
+    void invalid_accessToken_test() throws Exception {
+        // given
+
+        String accessToken = "112e3";
+
+
+        // then
+
+        ResultActions result = mvc.perform(
+                MockMvcRequestBuilders
+                        .get("/api/menti/3")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        String responseBody = result.andReturn().getResponse().getContentAsString();
+        System.out.println("responseBody = " + responseBody);
+
+        result.andExpect(MockMvcResultMatchers.jsonPath("$.success").value(false));
+        result.andExpect(MockMvcResultMatchers.jsonPath("$.error.code").value(9000));
+
+    }
+
+
     class RequestDTO {
         private String loginId;
         private String password;

--- a/src/test/java/com/theZ/dotoring/app/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/theZ/dotoring/app/auth/controller/AuthControllerTest.java
@@ -1,0 +1,80 @@
+package com.theZ.dotoring.app.auth.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@ActiveProfiles("local")
+@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private ObjectMapper om;
+    @Test
+    @DisplayName("멘티 로그인 테스트")
+    void login_test() throws Exception {
+        // given
+
+        String loginId = "dotoring92";
+        String password = "dotoring92@@";
+
+        // when
+
+        RequestDTO requestDTO = new RequestDTO(loginId, password);
+        String requestBody = om.writeValueAsString(requestDTO);
+
+        // then
+
+        ResultActions result = mvc.perform(
+                MockMvcRequestBuilders
+                        .post("/member/login")
+                        .content(requestBody)
+                        .contentType("application/json")
+        );
+
+        String responseBody = result.andReturn().getResponse().getContentAsString();
+        System.out.println("responseBody = " + responseBody);
+
+        result.andExpect(MockMvcResultMatchers.jsonPath("$.success").value(true));
+
+    }
+
+    class RequestDTO {
+        private String loginId;
+        private String password;
+
+        public RequestDTO(String loginId, String password) {
+            this.loginId = loginId;
+            this.password = password;
+        }
+
+        public String getLoginId() {
+            return loginId;
+        }
+
+        public void setLoginId(String loginId) {
+            this.loginId = loginId;
+        }
+
+        public String getPassword() {
+            return password;
+        }
+
+        public void setPassword(String password) {
+            this.password = password;
+        }
+    }
+}

--- a/src/test/java/com/theZ/dotoring/app/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/theZ/dotoring/app/auth/controller/AuthControllerTest.java
@@ -1,6 +1,7 @@
 package com.theZ.dotoring.app.auth.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.theZ.dotoring.app.auth.AuthConstants;
 import com.theZ.dotoring.app.auth.model.Token;
 import com.theZ.dotoring.app.memberAccount.model.MemberAccount;
 import com.theZ.dotoring.enums.MemberType;
@@ -16,6 +17,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
+import javax.servlet.http.Cookie;
 import java.time.Instant;
 
 @ActiveProfiles("local")
@@ -68,13 +70,12 @@ class AuthControllerTest {
 
         String accessToken = "112e3";
 
-
         // then
 
         ResultActions result = mvc.perform(
                 MockMvcRequestBuilders
                         .get("/api/menti/3")
-                        .header("Authorization", "Bearer " + accessToken)
+                        .header("Authorization", AuthConstants.TOKEN_TYPE + accessToken)
                         .contentType(MediaType.APPLICATION_JSON)
         );
 
@@ -99,7 +100,7 @@ class AuthControllerTest {
         ResultActions result = mvc.perform(
                 MockMvcRequestBuilders
                         .get("/api/menti/3")
-                        .header("Authorization",expiredToken)
+                        .header("Authorization",AuthConstants.TOKEN_TYPE + expiredToken)
                         .contentType(MediaType.APPLICATION_JSON)
         );
 
@@ -111,7 +112,31 @@ class AuthControllerTest {
 
     }
 
-
+//    @Test
+//    @DisplayName("유효기간이 지난 AccessToken과 정상적인 RefreshToken 제공 즉 토큰 재발행행 , 새로운 AccessToken과 RefreshToken을 제공")
+//    void reissue_test() throws Exception {
+//        // given
+//
+//        String expiredToken = token.generateAccessToken(makeMemberAccount(), Instant.now().minusSeconds(172800));
+//        String refreshToken = token.generateRefreshToken(makeMemberAccount(), Instant.now()); // 정상 리프레시 토큰
+//
+//
+//        // then
+//
+//        ResultActions result = mvc.perform(
+//                MockMvcRequestBuilders
+//                        .post("/api/auth/reIssue")
+//                        .header("Authorization",AuthConstants.TOKEN_TYPE + expiredToken)
+//                        .cookie(new Cookie("refreshToken",AuthConstants.TOKEN_TYPE + refreshToken))
+//                        .contentType(MediaType.APPLICATION_JSON)
+//        );
+//
+//        String responseBody = result.andReturn().getResponse().getContentAsString();
+//        System.out.println("responseBody = " + responseBody);
+//
+//        result.andExpect(MockMvcResultMatchers.jsonPath("$.success").value(true));
+//
+//    }
 
 
 

--- a/src/test/java/com/theZ/dotoring/app/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/theZ/dotoring/app/auth/controller/AuthControllerTest.java
@@ -64,6 +64,30 @@ class AuthControllerTest {
     }
 
     @Test
+    @DisplayName("정상적인 AccessToken을 줄 때")
+    void accessToken_test() throws Exception {
+
+        // given
+        String accessToken = token.generateAccessToken(makeMemberAccount(), Instant.now());
+
+
+        // then
+
+        ResultActions result = mvc.perform(
+                MockMvcRequestBuilders
+                        .get("/api/mento/5")
+                        .header(AuthConstants.AUTH_HEADER, AuthConstants.TOKEN_TYPE + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        String responseBody = result.andReturn().getResponse().getContentAsString();
+        System.out.println("responseBody = " + responseBody);
+
+        result.andExpect(MockMvcResultMatchers.jsonPath("$.success").value(true));
+
+    }
+
+    @Test
     @DisplayName("잘못된 AccessToken을 줄 때, error.code는 9000 반환")
     void invalid_accessToken_test() throws Exception {
         // given
@@ -75,7 +99,7 @@ class AuthControllerTest {
         ResultActions result = mvc.perform(
                 MockMvcRequestBuilders
                         .get("/api/menti/3")
-                        .header("Authorization", AuthConstants.TOKEN_TYPE + accessToken)
+                        .header(AuthConstants.AUTH_HEADER, AuthConstants.TOKEN_TYPE + accessToken)
                         .contentType(MediaType.APPLICATION_JSON)
         );
 
@@ -100,7 +124,7 @@ class AuthControllerTest {
         ResultActions result = mvc.perform(
                 MockMvcRequestBuilders
                         .get("/api/menti/3")
-                        .header("Authorization",AuthConstants.TOKEN_TYPE + expiredToken)
+                        .header(AuthConstants.AUTH_HEADER,AuthConstants.TOKEN_TYPE + expiredToken)
                         .contentType(MediaType.APPLICATION_JSON)
         );
 
@@ -112,31 +136,29 @@ class AuthControllerTest {
 
     }
 
-//    @Test
-//    @DisplayName("유효기간이 지난 AccessToken과 정상적인 RefreshToken 제공 즉 토큰 재발행행 , 새로운 AccessToken과 RefreshToken을 제공")
-//    void reissue_test() throws Exception {
-//        // given
-//
-//        String expiredToken = token.generateAccessToken(makeMemberAccount(), Instant.now().minusSeconds(172800));
-//        String refreshToken = token.generateRefreshToken(makeMemberAccount(), Instant.now()); // 정상 리프레시 토큰
-//
-//
-//        // then
-//
-//        ResultActions result = mvc.perform(
-//                MockMvcRequestBuilders
-//                        .post("/api/auth/reIssue")
-//                        .header("Authorization",AuthConstants.TOKEN_TYPE + expiredToken)
-//                        .cookie(new Cookie("refreshToken",AuthConstants.TOKEN_TYPE + refreshToken))
-//                        .contentType(MediaType.APPLICATION_JSON)
-//        );
-//
-//        String responseBody = result.andReturn().getResponse().getContentAsString();
-//        System.out.println("responseBody = " + responseBody);
-//
-//        result.andExpect(MockMvcResultMatchers.jsonPath("$.success").value(true));
-//
-//    }
+    @Test
+    @DisplayName("유효기간이 지난 AccessToken과 정상적인 RefreshToken 제공 즉 토큰 재발행행 , 새로운 AccessToken과 RefreshToken을 제공")
+    void reissue_test() throws Exception {
+
+        // given
+        String expiredToken = token.generateAccessToken(makeMemberAccount(), Instant.now().minusSeconds(172800));
+        String refreshToken = token.generateRefreshToken(makeMemberAccount(), Instant.now()); // 정상 리프레시 토큰
+
+
+        // then
+        ResultActions result = mvc.perform(
+                MockMvcRequestBuilders
+                        .post("/api/auth/reIssue")
+                        .header(AuthConstants.AUTH_HEADER,AuthConstants.TOKEN_TYPE + expiredToken)
+                        .cookie(new Cookie("refreshToken",AuthConstants.TOKEN_TYPE + refreshToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        String responseBody = result.andReturn().getResponse().getContentAsString();
+        System.out.println("responseBody = " + responseBody);
+
+        result.andExpect(MockMvcResultMatchers.jsonPath("$.success").value(true));
+    }
 
 
 


### PR DESCRIPTION
### 주요 내용

- 엑세스 토큰 만료될 시 재 요청 기능 구현
- 엑세스 토큰이 만료되고, 리프레시 토큰이 정상적일 때 리프래시 토큰 재발행 기능 구현
- 엑세스 토큰이 만료되고, 리프레시 토큰이 비정상적이거나 유효기간이 지났을 경우 재로그인 요청보내는 기능 구현
- 해당 기능들 테스트

관련 이슈 : https://github.com/Team-Neoul/Neoul_Dotoring-BE/issues/50