### PR TITLE
CI 워크플로우 설정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,42 @@
+on:
+  pull_request:
+    branches:
+      - release  # 'release' 브랜치로 PR이 생성될 때만 실행
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'corretto'  #Amazon Corretto 사용
+
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      - name: Build and Test
+        run: ./gradlew clean build
+
+      - name: Run Spring Boot App for 30 seconds
+        run: |
+          export SPRING_PROFILES_ACTIVE=test
+          ./gradlew bootRun &
+          APP_PID=$!
+          sleep 30
+          kill $APP_PID
+        continue-on-error: false


### PR DESCRIPTION
CI 워크플로우 설정

- release 브랜치로 PR이 생성될때만 실행
- Gradle 의존성 캐시하여 빌드 시간 단축
- 프로젝트 실행후 오류 발생시 종료

관련 이슈 : https://github.com/Team-Neoul/Neoul_Dotoring-BE/issues/71