### PR TITLE
Mento, Menti Nickname 조회시 CustomException 반환

### DIFF
--- a/src/main/java/com/theZ/dotoring/app/chat/entity/ChatMessage.java
+++ b/src/main/java/com/theZ/dotoring/app/chat/entity/ChatMessage.java
@@ -18,7 +18,7 @@ public class ChatMessage extends CommonEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "chatMessageId", nullable = false)
+    @Column(name = "chat_message_id", nullable = false)
     private Long id;
 
     //채팅방 ID

--- a/src/main/java/com/theZ/dotoring/app/memberAccount/service/MemberAccountService.java
+++ b/src/main/java/com/theZ/dotoring/app/memberAccount/service/MemberAccountService.java
@@ -13,6 +13,7 @@ import com.theZ.dotoring.app.mento.dto.SaveMentoRqDTO;
 import com.theZ.dotoring.app.mento.repository.MentoRepository;
 import com.theZ.dotoring.common.MessageCode;
 import com.theZ.dotoring.enums.MemberType;
+import com.theZ.dotoring.exception.NotFoundMemberException;
 import com.theZ.dotoring.exception.signupException.LoginIdDuplicateException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -163,19 +164,17 @@ public class MemberAccountService{
         memberAccount.updatePassword(updateMemberPasswordRequestDTO.getPassword());
     }
 
-    public String getMemberNickname(MemberAccount memberAccount){
+    public String getMemberNickname(MemberAccount memberAccount) throws NotFoundMemberException {
 
         // 멘토라면
         if (Objects.equals(memberAccount.getMemberType().toString(), "MENTO")){
             return mentoRepository.findMentoByMemberAccountId(memberAccount.getId())
-                    // todo CustomException 작성하기
-                    .orElseThrow(RuntimeException::new)
+                    .orElseThrow(() -> new NotFoundMemberException(MessageCode.MEMBER_NOT_FOUND))
                     .getNickname();
         }
 
         return mentiRepository.findMentiByMemberAccountId(memberAccount.getId())
-                // todo CustomException 작성하기
-                .orElseThrow(RuntimeException::new)
+                .orElseThrow(() -> new NotFoundMemberException(MessageCode.MEMBER_NOT_FOUND))
                 .getNickname();
     }
 }


### PR DESCRIPTION
### 반영사항

- Mento, Menti 닉네임 조회시 존재하지 않는 유저일 경우 Custom Exception 반환
- Presentation 계층에 예외 책임 전달
