### PR TITLE
지원사업 상세 조회 구현

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,14 +5,8 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="76b9bcd3-772d-4ab2-9d96-c4ee18f15126" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/.gradle/buildOutputCleanup/buildOutputCleanup.lock" beforeDir="false" afterPath="$PROJECT_DIR$/.gradle/buildOutputCleanup/buildOutputCleanup.lock" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.gradle/file-system.probe" beforeDir="false" afterPath="$PROJECT_DIR$/.gradle/file-system.probe" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/build/generated/sources/annotationProcessor/java/main/com/theZ/dotoring/app/letter/mapper/LetterMapperImpl.java" beforeDir="false" afterPath="$PROJECT_DIR$/build/generated/sources/annotationProcessor/java/main/com/theZ/dotoring/app/letter/mapper/LetterMapperImpl.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/build/generated/sources/annotationProcessor/java/main/com/theZ/dotoring/app/room/mapper/RoomMapperImpl.java" beforeDir="false" afterPath="$PROJECT_DIR$/build/generated/sources/annotationProcessor/java/main/com/theZ/dotoring/app/room/mapper/RoomMapperImpl.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/com/theZ/dotoring/app/notification/controller/NotificationController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/theZ/dotoring/app/notification/controller/NotificationController.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/com/theZ/dotoring/app/notification/model/Notification.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/theZ/dotoring/app/notification/model/Notification.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/com/theZ/dotoring/app/notification/repository/NotificationRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/theZ/dotoring/app/notification/repository/NotificationRepository.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/com/theZ/dotoring/app/notification/service/NotificationService.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/theZ/dotoring/app/notification/service/NotificationService.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -75,7 +69,7 @@
     "RunOnceActivity.OpenProjectViewOnStart": "true",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "WebServerToolWindowFactoryState": "false",
-    "git-widget-placeholder": "feat#103",
+    "git-widget-placeholder": "feat#105",
     "last_opened_file_path": "/Users/iseung-geon/dotoring_be",
     "node.js.detected.package.eslint": "true",
     "node.js.detected.package.tslint": "true",
@@ -283,7 +277,7 @@
       <workItem from="1701363046135" duration="4225000" />
       <workItem from="1702291395767" duration="868000" />
       <workItem from="1704114059412" duration="10899000" />
-      <workItem from="1704186274026" duration="8322000" />
+      <workItem from="1704186274026" duration="10001000" />
     </task>
     <servers />
   </component>

--- a/src/main/java/com/theZ/dotoring/app/notification/controller/NotificationController.java
+++ b/src/main/java/com/theZ/dotoring/app/notification/controller/NotificationController.java
@@ -1,6 +1,7 @@
 package com.theZ.dotoring.app.notification.controller;
 
 import com.theZ.dotoring.app.memberAccount.model.MemberAccount;
+import com.theZ.dotoring.app.notification.dto.NotificationDetailDTO;
 import com.theZ.dotoring.app.notification.dto.NotificationReqDTO;
 import com.theZ.dotoring.app.notification.dto.NotificationResDTO;
 import com.theZ.dotoring.app.notification.service.NotificationService;
@@ -32,6 +33,14 @@ public class NotificationController {
     public ApiResponse<ApiResponse.CustomBody<NotificationResDTO>> getNotificationByFilter(@RequestParam String title, @RequestParam String goal, @RequestParam boolean isClose){
 
         NotificationResDTO notificationResDTO =  notificationService.getNotificationByFilter(title, goal, isClose);
+
+        return ApiResponseGenerator.success(notificationResDTO, HttpStatus.OK);
+    }
+
+    @GetMapping(value = "/notification/{notificationId}")
+    public ApiResponse<ApiResponse.CustomBody<NotificationDetailDTO>> getNotification(@AuthenticationPrincipal MemberAccount memberAccount, @PathVariable Long notificationId){
+
+        NotificationDetailDTO notificationResDTO =  notificationService.getNotification(memberAccount, notificationId);
 
         return ApiResponseGenerator.success(notificationResDTO, HttpStatus.OK);
     }

--- a/src/main/java/com/theZ/dotoring/app/notification/dto/NotificationDetailDTO.java
+++ b/src/main/java/com/theZ/dotoring/app/notification/dto/NotificationDetailDTO.java
@@ -1,0 +1,44 @@
+package com.theZ.dotoring.app.notification.dto;
+
+import com.theZ.dotoring.app.notification.model.Notification;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+public class NotificationDetailDTO {
+
+    private String notificationName;
+
+    private String writerMajor;
+
+    private List<String> goals;
+
+    private String introduce;
+
+    private int maxRecruitment;
+
+    private int curRecruitment;
+
+    private boolean isWriter;
+
+    public static NotificationDetailDTO of(Notification notification, String memberMajor, String memberNickname){
+        return NotificationDetailDTO.builder()
+                .notificationName(notification.getTitle())
+                .writerMajor(memberMajor)
+                .goals(notification.getNotificationGoals())
+                .introduce(notification.getIntroduction())
+                .maxRecruitment(notification.getMaxRecruitment())
+                .curRecruitment(notification.getCurRecruitment())
+                .isWriter(memberIsWriter(memberNickname, notification.getAuthor()))
+                .build();
+    }
+
+    private static boolean memberIsWriter(String memberNickname, String notificationAuthor){
+        return memberNickname.equals(notificationAuthor);
+    }
+}

--- a/src/main/java/com/theZ/dotoring/app/notification/service/NotificationService.java
+++ b/src/main/java/com/theZ/dotoring/app/notification/service/NotificationService.java
@@ -5,10 +5,7 @@ import com.theZ.dotoring.app.menti.model.Menti;
 import com.theZ.dotoring.app.menti.repository.MentiRepository;
 import com.theZ.dotoring.app.mento.model.Mento;
 import com.theZ.dotoring.app.mento.repository.MentoRepository;
-import com.theZ.dotoring.app.notification.dto.NotificationReqDTO;
-import com.theZ.dotoring.app.notification.dto.NotificationResDTO;
-import com.theZ.dotoring.app.notification.dto.NotificationSaveResDTO;
-import com.theZ.dotoring.app.notification.dto.NotificationUpdateResDTO;
+import com.theZ.dotoring.app.notification.dto.*;
 import com.theZ.dotoring.app.notification.model.Notification;
 import com.theZ.dotoring.app.notification.repository.NotificationRepository;
 import com.theZ.dotoring.app.notification.repository.NotificationRepositoryImpl;
@@ -60,7 +57,6 @@ public class NotificationService {
         return NotificationUpdateResDTO.of(notification, map.get("memberNickname"), map.get("memberMajor"));
     }
 
-
     @Transactional(readOnly = true)
     public NotificationResDTO getNotificationByFilter(String title, String goal, boolean isClose){
         List<Notification> notifications = notificationRepositoryImpl.getNotificationByFilter(title, goal, isClose);
@@ -68,7 +64,14 @@ public class NotificationService {
         return new NotificationResDTO(notifications);
     }
 
+    @Transactional(readOnly = true)
+    public NotificationDetailDTO getNotification(MemberAccount memberAccount, Long notificationId){
+        Notification notification = notificationRepository.findById(notificationId).orElseThrow(() -> new RuntimeException("해당 지원 공고가 존재하지 않습니다."));
 
+        Map<String, String> map = getMemberNicknameAndMajor(memberAccount);
+
+        return NotificationDetailDTO.of(notification, map.get("memberMajor"), map.get("memberNickname"));
+    }
 
     /***
      * Member의 멘토나 멘티 분기에 따라서 닉네임, 전공을 Map 자료구조로 반환하는 메서드


### PR DESCRIPTION
지원사업 상세 조회를 구현함에 있어서 Member와 Notifcation 간 관계를 끊음으로써 지연 로딩과 같은 문제로부터 자유로움

관계를 끊은 이유는 아래와 같다.
1. MemberAccount를 연결하더라도, 매번 Mento와 Menti 여부에 따른 추가 쿼리 발생 
2. 매번 지연로딩으로 인한 쿼리가 발생하는 점